### PR TITLE
avoid unnecessary removed/added messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :test do
   gem "minitest-reporters"
   gem "mocha"
   gem "rack-test", require: "rack/test"
+  gem "rake"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rake (10.5.0)
     ruby-progressbar (1.7.5)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -54,6 +55,7 @@ DEPENDENCIES
   pry
   puma
   rack-test
+  rake
   sinatra
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require "rake/testtask"
+
+task default: :test
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.pattern = "test/*_test.rb"
+end

--- a/lib/label.rb
+++ b/lib/label.rb
@@ -11,15 +11,21 @@ class Label
   end
 
   def add_to(issue)
+    return if added_to_issue?(issue)
     ensure_label_exists
     github.add_labels_to_an_issue(repo, issue.number, [name])
   end
 
   def remove_from(issue)
+    return unless added_to_issue?(issue)
     github.remove_label(repo, issue.number, name)
   end
 
   private
+
+    def added_to_issue?(issue)
+      github.labels_for_issue(repo, issue.number).map(&:name).include?(name.to_s)
+    end
 
     def ensure_label_exists
       github.label(repo, name)

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -18,8 +18,15 @@ class PayloadTest < Minitest::Test
   end
 
   def test_adding_reviewed_label_if_given_recyle
+    github.expects(:labels_for_issue).with("balvig/cp-8", 1).once.returns([stub(name: "Reviewed")])
     github.expects(:remove_label).with("balvig/cp-8", 1, :Reviewed).once
     create_payload(:comment_recycle).process
+  end
+
+  def test_ignoring_comment_if_already_added
+    github.expects(:labels_for_issue).with("balvig/cp-8", 1).once.returns([stub(name: "Reviewed")])
+    github.expects(:add_labels_to_an_issue).never
+    create_payload(:comment_plus_one).process
   end
 
   def test_not_adding_labels_to_plain_issues
@@ -42,6 +49,6 @@ class PayloadTest < Minitest::Test
     end
 
     def github
-      @github ||= stub(label: true, add_label: true)
+      @github ||= stub(label: true, add_label: true, labels_for_issue: [])
     end
 end


### PR DESCRIPTION
Strangely GitHub will sometimes show the "CP-8 added label" when trying to add a label that has already been added. This makes sure labels are only added/removed if they haven't been already.