### PR TITLE
Automatically add comment to stale issues/PRs

### DIFF
--- a/lib/event/pull_request.rb
+++ b/lib/event/pull_request.rb
@@ -1,5 +1,7 @@
 class Event
   class PullRequest < Event
+    WEEK = 7 * 24 * 60 * 60
+
     def process
       case
       when opened? && title.include?("[WIP]")
@@ -10,6 +12,7 @@ class Event
       when edited? && !title.include?("[WIP]")
         remove_label(:WIP)
       end
+      report_stale_issues
     end
 
     private
@@ -24,6 +27,24 @@ class Event
 
       def title
         issue.title
+      end
+
+      def report_stale_issues
+        stale_issues.each do |issue|
+          github.add_comment(repo, issue.number, "[BEEP BOOP] Hi there!\n\nJust a reminder that this issue/PR hasn't been updated in _5 weeks_ and should probably be closed and labelled `icebox` for now.\n\nFeel free to re-open in the future if/when it becomes relevant again! :heart:")
+        end
+      end
+
+      def stale_issues
+        github.search_issues("repo:#{repo} is:open updated:<#{stale_pr_cutoff_date}").items
+      end
+
+      def stale_pr_cutoff_date
+        (Time.now - 5 * WEEK).iso8601
+      end
+
+      def github
+        Cp8.github_client
       end
   end
 end

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -2,7 +2,15 @@ require "test_helper"
 
 class PayloadTest < Minitest::Test
   def setup
+    ENV["TZ"] = "UTC"
+    Time.stubs(:now).returns(Time.at(0))
     Cp8.github_client = github
+  end
+
+  def test_closing_stale_prs
+    github.expects(:search_issues).with("repo:balvig/cp-8 is:open updated:<1969-11-27T00:00:00+00:00").once.returns(stub(items: [stub(number: 1)]))
+    github.expects(:add_comment)
+    create_payload(:pull_request_removed_wip).process
   end
 
   def test_creating_labels_if_they_dont_exist
@@ -69,6 +77,6 @@ class PayloadTest < Minitest::Test
     end
 
     def github
-      @github ||= stub(label: true, add_label: true, labels_for_issue: [])
+      @github ||= stub(label: true, add_label: true, labels_for_issue: [], search_issues: stub(items: []))
     end
 end


### PR DESCRIPTION
Scans for old PRs issues whenever a PR changes (in lieu of a proper cron job for now).
Will eventually automatically close issues.

![test_for_pr_by_balvig_ _pull_request__1_ _balvig_cp-8](https://cloud.githubusercontent.com/assets/104138/15067599/8d613f16-13ac-11e6-9cfa-70d93ca529b5.png)
