### PR TITLE
Exclude PR owner that comments plus one to get reviewed

### DIFF
--- a/lib/events/comment.rb
+++ b/lib/events/comment.rb
@@ -6,7 +6,7 @@ module Events
     def process
       case
       when PLUS_ONE.any? { |word| body.include?(word) }
-        add_label(:Reviewed)
+        add_label(:Reviewed) if not_self_reviewed?
       when RECYCLE.any? { |word| body.include?(word) }
         remove_label(:Reviewed)
       end
@@ -14,8 +14,24 @@ module Events
 
     private
 
+      def comment
+        @_comment ||= payload.comment
+      end
+
       def body
-        payload.comment.body
+        comment.body
+      end
+
+      def commenter
+        comment.user.login
+      end
+
+      def owner
+        issue.user.login
+      end
+
+      def not_self_reviewed?
+        commenter != owner
       end
   end
 end

--- a/test/fixtures/comment_own.json
+++ b/test/fixtures/comment_own.json
@@ -54,7 +54,7 @@
     "issue_url": "https://api.github.com/repos/balvig/cp-8/issues/1",
     "id": 189682850,
     "user": {
-      "login": "JuanitoFatas",
+      "login": "balvig",
       "id": 104138,
       "avatar_url": "https://avatars.githubusercontent.com/u/104138?v=3",
       "gravatar_id": "",
@@ -74,7 +74,7 @@
     },
     "created_at": "2016-02-27T17:01:12Z",
     "updated_at": "2016-02-27T17:01:12Z",
-    "body": ":+1: "
+    "body": "👍"
   },
   "repository": {
     "id": 52675348,

--- a/test/fixtures/comment_plus_one.json
+++ b/test/fixtures/comment_plus_one.json
@@ -54,7 +54,7 @@
     "issue_url": "https://api.github.com/repos/balvig/cp-8/issues/1",
     "id": 189682850,
     "user": {
-      "login": "balvig",
+      "login": "JuanitoFatas",
       "id": 104138,
       "avatar_url": "https://avatars.githubusercontent.com/u/104138?v=3",
       "gravatar_id": "",

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -47,6 +47,11 @@ class PayloadTest < Minitest::Test
     create_payload(:comment_plus_one).process
   end
 
+  def test_not_adding_reviewed_label_if_myself
+    github.expects(:add_labels_to_an_issue).never
+    create_payload(:comment_own).process
+  end
+
   def test_not_adding_labels_to_plain_issues
     github.expects(:add_labels_to_an_issue).never
     create_payload(:issue_comment).process


### PR DESCRIPTION
I was trying to [compliment our colleague](https://github.com/cookpad/global-web/pull/4143#issuecomment-258788496) but got self-reviewed.


This PR makes sure PR owner cannot get reviewed label by commenting 👍 